### PR TITLE
Report Execution Patches Improved

### DIFF
--- a/Projects/SealLibrary/Model/Report.cs
+++ b/Projects/SealLibrary/Model/Report.cs
@@ -894,6 +894,12 @@ namespace Seal.Model
         public Dictionary<string, string> InputRestrictions = new Dictionary<string, string>();
 
         /// <summary>
+        /// When executing a report from SWI, if we keep the values of the report default restrictions in case of omission
+        /// </summary>
+        [XmlIgnore]
+        public bool InputRestrictionsUserDefaults = false;
+
+        /// <summary>
         /// Input restriction value for a given key
         /// </summary>
         public string GetInputRestriction(string key)

--- a/Projects/SealLibrary/Model/ReportExecution.cs
+++ b/Projects/SealLibrary/Model/ReportExecution.cs
@@ -384,13 +384,29 @@ namespace Seal.Model
             string dateMessage = report.Translate("Use the date format '{0}' or one of the following keywords:", report.CultureInfo.DateTimeFormat.ShortDatePattern) + " " + report.DateKeywordsList;
 
             DateTime dt;
+
+            if (report.InputRestrictionsUserDefaults && string.IsNullOrEmpty(val1))
+                val1 = restriction.Value1;
+
             string val = val1;
             if (restriction.IsDateTime)
             {
                 if (string.IsNullOrEmpty(val))
                 {
-                    restriction.Date1 = DateTime.MinValue;
-                    restriction.Date1Keyword = "";
+                    if (report.InputRestrictionsUserDefaults)
+                    {
+                        if (DateTime.MinValue.Equals(restriction.Date1))
+                            restriction.Date1Keyword = "";
+                        else
+                            val = restriction.Date1.ToString();
+                    }
+                    else
+                    {
+                        restriction.Date1 = DateTime.MinValue;
+                        restriction.Date1Keyword = "";
+                    }
+
+
                 }
                 else if (DateTime.TryParse(val, report.CultureInfo, DateTimeStyles.None, out dt))
                 {
@@ -414,13 +430,28 @@ namespace Seal.Model
 
             if (restriction.Prompt != PromptType.PromptOneValue)
             {
+                if (report.InputRestrictionsUserDefaults && string.IsNullOrEmpty(val2))
+                    val2 = restriction.Value2;
+                if (report.InputRestrictionsUserDefaults && string.IsNullOrEmpty(val3))
+                    val3 = restriction.Value3;
+                if (report.InputRestrictionsUserDefaults && string.IsNullOrEmpty(val4))
+                    val4 = restriction.Value4;
+
                 val = val2;
                 if (restriction.IsDateTime)
                 {
                     if (string.IsNullOrEmpty(val))
                     {
-                        restriction.Date2 = DateTime.MinValue;
-                        restriction.Date2Keyword = "";
+                        if (report.InputRestrictionsUserDefaults)
+                        {
+                            if (DateTime.MinValue.Equals(restriction.Date1))
+                                restriction.Date1Keyword = "";
+                        }
+                        else
+                        {
+                            restriction.Date1 = DateTime.MinValue;
+                            restriction.Date1Keyword = "";
+                        }
                     }
                     else if (DateTime.TryParse(val, report.CultureInfo, DateTimeStyles.None, out dt))
                     {
@@ -440,8 +471,16 @@ namespace Seal.Model
                 {
                     if (string.IsNullOrEmpty(val))
                     {
-                        restriction.Date3 = DateTime.MinValue;
-                        restriction.Date3Keyword = "";
+                        if (report.InputRestrictionsUserDefaults)
+                        {
+                            if (DateTime.MinValue.Equals(restriction.Date1))
+                                restriction.Date1Keyword = "";
+                        }
+                        else
+                        {
+                            restriction.Date1 = DateTime.MinValue;
+                            restriction.Date1Keyword = "";
+                        }
                     }
                     else if (DateTime.TryParse(val, report.CultureInfo, DateTimeStyles.None, out dt))
                     {
@@ -461,8 +500,16 @@ namespace Seal.Model
                 {
                     if (string.IsNullOrEmpty(val))
                     {
-                        restriction.Date4 = DateTime.MinValue;
-                        restriction.Date4Keyword = "";
+                        if (report.InputRestrictionsUserDefaults)
+                        {
+                            if (DateTime.MinValue.Equals(restriction.Date1))
+                                restriction.Date1Keyword = "";
+                        }
+                        else
+                        {
+                            restriction.Date1 = DateTime.MinValue;
+                            restriction.Date1Keyword = "";
+                        }
                     }
                     else if (DateTime.TryParse(val, report.CultureInfo, DateTimeStyles.None, out dt))
                     {
@@ -490,17 +537,19 @@ namespace Seal.Model
             }
             if (restriction.IsEnum)
             {
-                restriction.EnumValues.Clear();
+                List<string> selected_enum = new List<string>();
                 foreach (var enumVal in restriction.EnumRE.Values)
                 {
                     val = Report.GetInputRestriction(restriction.OptionHtmlId + enumVal.HtmlId);
                     if (val.ToLower() == "true")
                     {
-                        restriction.EnumValues.Add(enumVal.Id);
+                        selected_enum.Add(enumVal.Id);
                         //Check only one restriction
                         if (restriction.Prompt == PromptType.PromptOneValue) break;
                     }
                 }
+                if (selected_enum.Count > 0)
+                    restriction.EnumValues = selected_enum;
 
                 //check required flag
                 if (restriction.EnumValues.Count == 0 && restriction.Required)

--- a/Projects/SealLibrary/Model/ReportRestriction.cs
+++ b/Projects/SealLibrary/Model/ReportRestriction.cs
@@ -1327,7 +1327,7 @@ namespace Seal.Model
                 else
                 {
                     if (!HasValue1 && IsText) _SQLText = GetSQLValue("", FinalDate1, _operator);
-                    else _SQLText = (HasValue1 ? GetSQLValue(Value1, FinalDate1, _operator) : "NULL");
+                    else _SQLText = string.Format("({0})", (HasValue1 ? GetSQLValue(Value1, FinalDate1, _operator) : "NULL"));
                     _displayText = displayLabel + " " + (string.IsNullOrEmpty(OperatorLabel) ? "" : OperatorLabel + " ") + (HasValue1 ? GetDisplayValue(Value1, FinalDate1) : "?");
                     _displayRestriction = displayLabel + " " + (string.IsNullOrEmpty(OperatorLabel) ? "" : OperatorLabel + " ") + (HasValue1 ? GetDisplayRestriction(Value1, Date1Keyword, Date1) : "?");
                 }

--- a/Projects/SealWebServer/Controllers/HomeController.cs
+++ b/Projects/SealWebServer/Controllers/HomeController.cs
@@ -813,6 +813,9 @@ namespace SealWebServer.Controllers
             //Do not use input restrictions for navigation...
             if (report.IsNavigating) return;
 
+            // If we receive the "userdefaults" field we define the field
+            if (report.PreInputRestrictions.ContainsKey("usedefaults")) report.InputRestrictionsUserDefaults = Convert.ToBoolean(report.PreInputRestrictions["usedefaults"]);
+
             if (report.PreInputRestrictions.Count > 0)
             {
                 int i = 0;

--- a/Projects/SealWebServer/Controllers/HomeControllerSWI.cs
+++ b/Projects/SealWebServer/Controllers/HomeControllerSWI.cs
@@ -35,6 +35,7 @@ namespace SealWebServer.Controllers
                     WebUser.WebUserName = user;
                     WebUser.WebPassword = password;
                     WebUser.Token = token;
+                    WebUser.Request = Request;
                     Authenticate();
 
                     if (!WebUser.IsAuthenticated) throw new Exception(string.IsNullOrEmpty(WebUser.Error) ? Translate("Invalid user name or password") : WebUser.Error);


### PR DESCRIPTION
- THE SQL sentence of non enum commonValue restrictions (numeric, text, datetime...) were not include parenthesis, so didn't work with WHERE IN clauses. Now, parenthesis are included with every type of common value restrictions, so every kind of WHERE clause will work.
- If a report is executed from the SWI and the usedefaults attribute is set to "true", the report restriction values must be maintained if the restriction is not included in the executeReport request.
- The Request field was not being passed to the WebUser, causing an exception when logging in using the new JWT provider.