### PR TITLE
Report Execution Patches Improved

### DIFF
--- a/Projects/SealLibrary/Model/ReportExecution.cs
+++ b/Projects/SealLibrary/Model/ReportExecution.cs
@@ -550,6 +550,8 @@ namespace Seal.Model
                 }
                 if (selected_enum.Count > 0)
                     restriction.EnumValues = selected_enum;
+                else if (!Report.InputRestrictionsUserDefaults)
+                    restriction.EnumValues.Clear();
 
                 //check required flag
                 if (restriction.EnumValues.Count == 0 && restriction.Required)


### PR DESCRIPTION
- When saving an enum, if "InputRestrictionsUserDefaults" is "false", you must empty "EnumValues"