### PR TITLE
Fixed sub-totals when first line of data is incomplete

### DIFF
--- a/Projects/SealLibrary/Model/ReportExecution.cs
+++ b/Projects/SealLibrary/Model/ReportExecution.cs
@@ -1437,6 +1437,14 @@ namespace Seal.Model
                                 {
                                     subTotalLine[j].Cells.Add(dataTable[i, j]);
                                 }
+                                else if (subTotalLine[j].Element == null && dataTable[i, j].Element != null && dataTable[i, j].Element.PivotPosition == PivotPosition.Data)
+                                {
+                                    var sourceCell = dataTable[i, j];
+                                    totalCells.Add(subTotalLine[j]);
+                                    subTotalLine[j].Element = sourceCell.Element;
+                                    subTotalLine[j].FinalCssClass += " text-right";
+                                    subTotalLine[j].Cells.Add(sourceCell);
+                                }
                             }
                         }
                         i++;


### PR DESCRIPTION
In a cross-tab, when the "sub-totals" option is enabled for a given row, but the first line of data (of the current sub-totals group) is incomplete, the feature only compute sub-totals for data having non-null data in the first row. 
I think this is because of how the sub-total line is created ; cells of that new sub-total line are based on the content of the first line, so if the first line contain "blank" cells, the object is null, and because of `subTotalLine[j].Element != null` the content of following cells will never be added.
The code of my PR here take the possibility of having empty cells in account and will add the missing object in the sub-total at each line, and not only the first one.

Here is a view of what happens without the fix :
![image](https://user-images.githubusercontent.com/16225774/75973048-d94cfb00-5ed4-11ea-985b-f12ee9477a8a.png)
The first line and sub-totals lines missing are highlighted in orange
SQL to generate these data :
`select 'Group 1' as Groups, 'Subgroup1' as Subgroups, 'Col3' as Col, 4 as value from dual
union
select 'Group 1' as Groups, 'Subgroup2' as Subgroups, 'Col1' as Col, 1 as value from dual
union
select 'Group 1' as Groups, 'Subgroup2' as Subgroups, 'Col2' as Col, 3 as value from dual
union
select 'Group 1' as Groups, 'Subgroup2' as Subgroups, 'Col3' as Col, 1 as value from dual
union
select 'Group 1' as Groups, 'Subgroup3' as Subgroups, 'Col2' as Col, 4 as value from dual
union
select 'Group 1' as Groups, 'Subgroup4' as Subgroups, 'Col1' as Col, 5 as value from dual
union
select 'Group 1' as Groups, 'Subgroup4' as Subgroups, 'Col3' as Col, 8 as value from dual
union
select 'Group 2' as Groups, 'Subgroup1' as Subgroups, 'Col1' as Col, 2 as value from dual
union
select 'Group 2' as Groups, 'Subgroup1' as Subgroups, 'Col3' as Col, 6 as value from dual
union
select 'Group 2' as Groups, 'Subgroup2' as Subgroups, 'Col1' as Col, 1 as value from dual
union
select 'Group 2' as Groups, 'Subgroup2' as Subgroups, 'Col2' as Col, 2 as value from dual
union
select 'Group 2' as Groups, 'Subgroup2' as Subgroups, 'Col3' as Col, 4 as value from dual
union
select 'Group 2' as Groups, 'Subgroup3' as Subgroups, 'Col3' as Col, 1 as value from dual`

Below is a view of the same report with the fix :
![image](https://user-images.githubusercontent.com/16225774/75973577-ae16db80-5ed5-11ea-9d9a-bbdfbe249f7b.png)

Feel free to test, edit, correct or ignore if what I did is wrong and contact me if needed.
Regards