### PR TITLE
Adding configuration to be able to modify the Path Base when you use a Reverse Proxy

### DIFF
--- a/Projects.NETCore/SealWebServer/appsettings.Release.json
+++ b/Projects.NETCore/SealWebServer/appsettings.Release.json
@@ -10,6 +10,7 @@
   "SealConfiguration": {
     "RepositoryPath": "",
     "DebugMode": false,
+    "PathBaseProxy": null, // If you are using a reverse proxy and rewrite all urls to another base path you need to use this.
     "RunScheduler": false, //If true, the Scheduler is executed as a separate Thread in the Web Report Server (need Server configuration: Use 'Seal Report Scheduler' set to True),
     "SessionTimeout": 60,
     "SessionProvider": {

--- a/Projects.NETCore/SealWebServer/appsettings.json
+++ b/Projects.NETCore/SealWebServer/appsettings.json
@@ -9,6 +9,7 @@
   "AllowedHosts": "*",
   "SealConfiguration": {
     "RepositoryPath": "C:\\ProgramData\\Seal Report Repository",
+    "PathBaseProxy": null, // If you are using a reverse proxy and rewrite all urls to another base path you need to use this.
     "DebugMode": false,
     "RunScheduler": false, //If true, the Scheduler is executed as a separate Thread in the Web Report Server (need Server configuration: Use 'Seal Report Scheduler' set to True),
     "SessionTimeout": 60,


### PR DESCRIPTION
This change allows the use of a Base Path when using a Reverse Proxy.

I have tried using app.UsePathBase instead but it is ignored, while this option is not.

More information: https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/proxy-load-balancer?view=aspnetcore-3.1#deal-with-path-base-and-proxies-that-change-the-request-path


Example configuration:

In your nginx server add a location very similar to this:

location /sealreport/ {
        rewrite ^/sealreport(/.*)$ $1 break;
        proxy_pass http://{your .net core server};
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
}
location /report {
        return 301 /sealreport/;
}

In the appsettings.json configuration file, inside the SealConfiguration node, define or add the PathBaseProxy parameter, in the case of our example it would be "/sealreport"