### PR TITLE
Fix the path problem on linux environment

### DIFF
--- a/Projects.NETCore/SealLibrary/Model/Repository.cs
+++ b/Projects.NETCore/SealLibrary/Model/Repository.cs
@@ -641,7 +641,7 @@ namespace Seal.Model
             get
             {
 #if NETCOREAPP
-                return Path.Combine(RepositoryPath, "Assemblies\\NETCore"); 
+                return Path.Combine(RepositoryPath, "Assemblies/NETCore"); 
 #else
                 return Path.Combine(RepositoryPath, "Assemblies");
 #endif


### PR DESCRIPTION
Fix the path problem that SealConverter_NetCore.dll cannot be loaded on linux environment.