### PR TITLE
Add whether OpenID Connect is configured

### DIFF
--- a/Projects/SealWebServer/Controllers/HomeControllerSWI.cs
+++ b/Projects/SealWebServer/Controllers/HomeControllerSWI.cs
@@ -79,8 +79,8 @@ namespace SealWebServer.Controllers
                 }
 
                 //Audit
-                //Audit.LogAudit(AuditType.Login, WebUser);
-                //Audit.LogEventAudit(AuditType.EventLoggedUsers, SealSecurity.LoggedUsers.Count(i => i.IsAuthenticated).ToString());
+                Audit.LogAudit(AuditType.Login, WebUser);
+                Audit.LogEventAudit(AuditType.EventLoggedUsers, SealSecurity.LoggedUsers.Count(i => i.IsAuthenticated).ToString());
 
                 //Set repository defaults
                 var defaultGroup = WebUser.DefaultGroup;
@@ -719,8 +719,8 @@ namespace SealWebServer.Controllers
             {
                 if (WebUser != null) WebUser.Logout();
                 //Audit
-                //Audit.LogAudit(AuditType.Logout, WebUser);
-                //Audit.LogEventAudit(AuditType.EventLoggedUsers, SealSecurity.LoggedUsers.Count(i => i.IsAuthenticated).ToString());
+                Audit.LogAudit(AuditType.Logout, WebUser);
+                Audit.LogEventAudit(AuditType.EventLoggedUsers, SealSecurity.LoggedUsers.Count(i => i.IsAuthenticated).ToString());
                 //Clear session
                 NavigationContext.Navigations.Clear();
                 setSessionValue(SessionUser, null);
@@ -728,7 +728,13 @@ namespace SealWebServer.Controllers
                 setSessionValue(SessionUploadedFiles, null);
                 CreateWebUser();
 
-                return SignOut("Cookies", "oidc");
+                //SignOut
+                if (AuthenticationConfig.Enabled)
+                {
+                    return SignOut("Cookies", "oidc");
+                }
+
+                return Json(new { });
             }
             catch (Exception ex)
             {

--- a/Projects/SealWebServer/Models/Configuration/Authentication.cs
+++ b/Projects/SealWebServer/Models/Configuration/Authentication.cs
@@ -6,5 +6,10 @@
         public string AccessKeySecret { get; set; }
         public string ClientId { get; set; }
         public string Name { get; set; }
+
+        /// <summary>
+        /// Whether to enable the configuration
+        /// </summary>
+        public bool Enabled { get; set; }
     }
 }

--- a/Projects/SealWebServer/Views/Home/Main.cshtml
+++ b/Projects/SealWebServer/Views/Home/Main.cshtml
@@ -151,8 +151,13 @@
                         <input type="password" class="form-control" id="password" placeholder="@repository.TranslateWeb("Enter password")" />
                     </div>
                     <button id="login-modal-submit" class="btn btn-default btn-success btn-block"><span class="glyphicon glyphicon-off"></span> @repository.TranslateWeb("Login")</button>
-
-                    @Html.ActionLink(@authenticationConfig?.Name ?? "Login","Login","Home")
+                    @{
+                        if (authenticationConfig?.Enabled ?? false)
+                        {
+                            @Html.ActionLink(@authenticationConfig.Name ?? "Login", "Login", "Home")
+                        }
+                    }
+                   
                 </div>
                 <div class="modal-footer" style="text-align:left">
                     <span id="login-modal-error" class="label label-danger" style="font-size: 12px;"></span>

--- a/Projects/SealWebServer/appsettings.json
+++ b/Projects/SealWebServer/appsettings.json
@@ -25,6 +25,7 @@
     "ClientId": "interactive.confidential",
     "AccessKeySecret": "secret",
     "Id4EndPoint": "https://demo.identityserver.io/",
-    "Name": "identity"
+    "Name": "identity",
+    "Enabled": false  
   }
 }

--- a/Repository/Security/Security.xml
+++ b/Repository/Security/Security.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <SealSecurity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
-  <ProviderName>OpenId</ProviderName>
+  <ProviderName>No Security</ProviderName>
   <UseCustomScript>true</UseCustomScript>
   <Script>@{
     SecurityUser user = Model;

--- a/Repository/Security/Security.xml
+++ b/Repository/Security/Security.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <SealSecurity xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
   <ProviderName>OpenId</ProviderName>
+  <UseCustomScript>true</UseCustomScript>
   <Script>@{
     SecurityUser user = Model;
 	//Basic authentication script: use the user name and password to authenticate the user and set his name and security groups...


### PR DESCRIPTION
You can enable OpenID Connect using the AppSettings.
To test OpenID Connect, you need to configure Authentication in appSettings after building IdentityServer.
We need you to review the submission and consider the optimal solution for OpenID Connect. This submission is just a simple implementation.