### PR TITLE
Fix CommonValue when the enum is for Numeric or DateTime types

### DIFF
--- a/Projects/SealLibraryWin/Model/ReportRestriction.cs
+++ b/Projects/SealLibraryWin/Model/ReportRestriction.cs
@@ -1666,7 +1666,7 @@ namespace Seal.Model
             {
                 if (IsEnum)
                 {
-                    _SQLText = HasValue ? "'" + string.Join(",", EnumValues.Select(s => s.Replace("'", "''")).ToList()) + "'" : "NULL";
+                    _SQLText = HasValue ? "(" + string.Join(",", EnumValues.Select(s => GetSQLValue(s, IsDateTime ? DateTime.Parse(s) : FinalDate1, _operator)).ToList()) + ")" : "NULL";
                     _displayText = displayLabel + " " + (string.IsNullOrEmpty(OperatorLabel) ? "" : OperatorLabel + " ") + (HasValue ? EnumDisplayValue : "?");
                     _displayRestriction = _displayText;
                 }


### PR DESCRIPTION
Hi,

Here's my pull request regarding https://github.com/ariacom/Seal-Report/discussions/119
After a bit of additional research, I found an easier solution that make use of the existing "GetSQLValue" method.
With this, the DB-specific date formats should be supported.
Also, with this we don't have to do a nested if-else based on the type.

Have a nice day!
