### PR TITLE
Added a few options to the Excel export format

### DIFF
--- a/Repository/Views/Renderers/Excel/Report.config.cshtml
+++ b/Repository/Views/Renderers/Excel/Report.config.cshtml
@@ -4,6 +4,7 @@
     ReportViewTemplate Template = Model;
 
     //Parameters for this template
+    Template.Parameters.Add(new Parameter() { Name = "show_logo", DisplayName = "Show logo when printed", BoolValue = false, Description = "If true, the logo is inserted in the top right part of the header." });
     Template.Parameters.Add(new Parameter() { Name = "show_information", DisplayName = "Show report information", BoolValue = true, Description = "If true, report information is displayed in a dedicated sheet." });
     Template.Parameters.Add(new Parameter() { Name = "show_messages", DisplayName = "Show messages", BoolValue = false, Description = "If true, report execution messages are displayed in a dedicated sheet." });
     Template.Parameters.Add(new Parameter() { Name = "auto_fit_columns", DisplayName = "Auto Fit columns", BoolValue = true, Description = "If true, columns widths are ajusted with the cell content." });
@@ -28,4 +29,7 @@
                 EnumType = typeof(eOrientation)
             });
     Template.Parameters.Add(new Parameter() { Name = "printer_fit_page", DisplayName = "Printer fit to page", BoolValue = true, Description = "If true, the pages are adapted to the paper size when printing." });
+    Template.Parameters.Add(new Parameter() { Name = "printer_fit_width", DisplayName = "Printer fit to width", NumericValue = 1, Description = "Require 'Fit to page' set to true. Number of pages to fit in width, 0 for automatic." });
+    Template.Parameters.Add(new Parameter() { Name = "printer_fit_height", DisplayName = "Printer fit to height", NumericValue = 0, Description = "Require 'Fit to page' set to true. Number of pages to fit in height, 0 for automatic." });
+
 }

--- a/Repository/Views/Renderers/Excel/Report.cshtml
+++ b/Repository/Views/Renderers/Excel/Report.cshtml
@@ -29,7 +29,7 @@
 
         //Header & Footer
         var logoPath = Path.ChangeExtension(report.Repository.Configuration.LogoFilePath, "png");
-        if (File.Exists(logoPath))
+        if (File.Exists(logoPath) && renderer.GetBoolValue("show_logo"))
         {
             result.Worksheet.HeaderFooter.OddHeader.InsertPicture(Image.FromFile(logoPath), PictureAlignment.Right);
         }
@@ -51,6 +51,15 @@
             sheet.PrinterSettings.PaperSize = (ePaperSize)Enum.Parse(typeof(ePaperSize), renderer.GetValue("printer_paper_size"));
             sheet.PrinterSettings.Orientation = (eOrientation)Enum.Parse(typeof(eOrientation), renderer.GetValue("printer_orientation"));
             sheet.PrinterSettings.FitToPage = renderer.GetBoolValue("printer_fit_page");
+            sheet.PrinterSettings.FitToWidth = renderer.GetNumericValue("printer_fit_width");
+            sheet.PrinterSettings.FitToHeight = renderer.GetNumericValue("printer_fit_height");
+            sheet.PrinterSettings.LeftMargin = 0.314m;
+            sheet.PrinterSettings.RightMargin = 0.314m;
+            sheet.PrinterSettings.TopMargin = 0.59m;
+            sheet.PrinterSettings.BottomMargin = 0.59m;
+            sheet.PrinterSettings.HeaderMargin = 0.314m;
+            sheet.PrinterSettings.FooterMargin = 0.314m;
+
         }
 
         //Report information

--- a/Repository/Views/Renderers/Excel/TabPage.cshtml
+++ b/Repository/Views/Renderers/Excel/TabPage.cshtml
@@ -1,4 +1,8 @@
-﻿@using Seal.Model
+﻿@using DocumentFormat.OpenXml
+@using OfficeOpenXml
+@using System.IO
+@using System.Drawing
+@using Seal.Model
 @using Seal.Renderer
 @{
     Report report = Model;
@@ -9,6 +13,16 @@
     ExcelResult result = report.ExcelResult;
 
     if (renderer.GetBoolValue("new_sheet")) result.AddWorksheet(view.Name);
+
+    //Header & Footer
+    var logoPath = Path.ChangeExtension(report.Repository.Configuration.LogoFilePath, "png");
+    if (File.Exists(logoPath) && renderer.GetBoolValue("show_logo"))
+    {
+        result.Worksheet.HeaderFooter.OddHeader.InsertPicture(Image.FromFile(logoPath), PictureAlignment.Right);
+    }
+    result.Worksheet.HeaderFooter.OddHeader.LeftAlignedText = "&14&\"Arial,Regular Bold\" " + report.DisplayName;
+    result.Worksheet.HeaderFooter.OddFooter.RightAlignedText = report.Translate("Page") + $" {ExcelHeaderFooter.PageNumber}/{ExcelHeaderFooter.NumberOfPages}";
+    result.Worksheet.HeaderFooter.OddFooter.LeftAlignedText = ExcelHeaderFooter.FilePath + ExcelHeaderFooter.FileName;
 
     view.ParseChildren();
 }


### PR DESCRIPTION
Hi,

Here are a few options I needed and added. Also a few layout settings for the print view.

It adds the following :
- Option to show or not the logo in the print mode of Excel (added in the top right part of the header)
- Option to control how the table should fit, for example 1 page width but no limit in height, etc.
- The margin has been set to be approx 0.8 cm (converted from inches if I remember)
- The header is also added when there are tabs in a report that generate multiple worksheets

Have a nice day!