### PR TITLE
Load Script String replacement for NoSQL Sources

### DIFF
--- a/Projects/SealLibraryWin/Helpers/Helper.cs
+++ b/Projects/SealLibraryWin/Helpers/Helper.cs
@@ -1154,7 +1154,7 @@ namespace Seal.Helpers
             do
             {
                 index = sql.IndexOf(keyword, index);
-                if (index > 0)
+                if (index >= 0)
                 {
                     index += keyword.Length;
                     string restrictionName = "";

--- a/Projects/SealLibraryWin/Model/MetaSource.cs
+++ b/Projects/SealLibraryWin/Model/MetaSource.cs
@@ -135,6 +135,16 @@ namespace Seal.Model
         public bool IsNoSQL { get; set; } = false;
 
         /// <summary>
+        /// If true, this source contains only tables built from dedicated Razor Scripts (one for the definition and one for the load). The a LINQ query will then be used to fill the models.
+        /// </summary>
+#if WINDOWS
+        [DefaultValue("")]
+        [Category("Scripts"), DisplayName("Common Restrictions"), Description("A list of common restrictions used in the Load Scripts for this data source"), Id(5,3)]
+        [Editor(typeof(TemplateTextEditor), typeof(UITypeEditor))]
+#endif
+        public string CommonRestrictions { get; set; } = "";
+        public bool ShouldSerializeCommonRestrictions() { return !string.IsNullOrEmpty(CommonRestrictions); }
+        /// <summary>
         /// If true, this source contains only a table built from a database. The SQL engine will be used to fill the models.
         /// </summary>
         [XmlIgnore]

--- a/Projects/SealLibraryWin/Model/ReportSource.cs
+++ b/Projects/SealLibraryWin/Model/ReportSource.cs
@@ -43,6 +43,7 @@ namespace Seal.Model
 
                 GetProperty("InitScript").SetIsBrowsable(true);
                 GetProperty("InitScript").SetIsReadOnly(!string.IsNullOrEmpty(MetaSourceGUID));
+                GetProperty("CommonRestrictions").SetIsBrowsable(IsNoSQL);
 
                 GetProperty("Information").SetIsBrowsable(true);
                 GetProperty("Error").SetIsBrowsable(true);
@@ -180,6 +181,7 @@ namespace Seal.Model
                     IsDefault = source.IsDefault;
                     IsNoSQL = source.IsNoSQL;
                     InitScript = source.InitScript;
+                    CommonRestrictions = source.CommonRestrictions;
                     _metaSourceName = source.Name;
                     foreach (var item in source.Connections)
                     {

--- a/Repository/Sources/TableTemplates/HTTPClient JSON.cshtml
+++ b/Repository/Sources/TableTemplates/HTTPClient JSON.cshtml
@@ -2,6 +2,8 @@
 @{
     MetaTable table = Model;
 
+    table.Source.CommonRestrictions = "pattern";
+
     table.DefinitionScript = @"@using System.Data
 @{
     MetaTable metaTable = Model;
@@ -26,6 +28,7 @@
     ReportModel reportModel = metaTable.NoSQLModel;
     Report report = (reportModel != null ? reportModel.Report : null);
     List<ReportRestriction> restrictions = (reportModel != null ? reportModel.Restrictions : null);
+    List<ReportRestriction> commonRestrictions = (reportModel != null ? reportModel.CommonRestrictions : null);
     
     var client = new HttpClient();
     client.DefaultRequestHeaders.Accept.Clear();
@@ -51,6 +54,13 @@
         
         //Post SWISearch
         json = JsonConvert.SerializeObject(new { path=@""\"", pattern=""er""} );
+        if (commonRestrictions != null && commonRestrictions.Count > 0) {
+            var pattern = commonRestrictions.FirstOrDefault(cr => cr.Name == ""pattern"");
+            if (pattern != null) {
+                json = JsonConvert.SerializeObject(new { path=@""\"", pattern=pattern} );
+            }
+        }
+
         data = new StringContent(json, System.Text.Encoding.UTF8, ""application/json"");
         responsePost = client.PostAsync(url+""SWISearch"", data).Result;  
         responseBody = responsePost.Content.ReadAsStringAsync().Result;


### PR DESCRIPTION
Added access to CommonRestrictions as a Key Value Pair string replacement mechanism for NoSQL scripts to allow the API calls to be modified by the CommonRestrictions mechanism (Value Only)