### PR TITLE
Fix dependant enumerated list reload after report execution

### DIFF
--- a/Projects/SealLibraryWin/Model/ReportExecution.cs
+++ b/Projects/SealLibraryWin/Model/ReportExecution.cs
@@ -2379,7 +2379,7 @@ namespace Seal.Model
                     {
                         CurrentEnumValues.Add(r.EnumRE, null);
                         //First: SQL, Second: Script for list for Script dependencies
-                        CurrentEnumValues[r.EnumRE] = new List<string> { restriction.EnumSQLValue, restriction.EnumLINQValue };
+                        CurrentEnumValues[r.EnumRE] = new List<string> { r.EnumSQLValue, r.EnumLINQValue };
                     }
                 }
 


### PR DESCRIPTION
I came across a problem with depending enumerated lists loaded via script.

### **Problem description**

I have an enumerated lists wich depends on the results of another one and is loaded via the following script:

```
@using LinqToDB.Data
@using Siglas.Queries.EnumeratedLists
@using Siglas.Utils.Data
@{
#nullable enable
    MetaEnum metaEnum = Model;
    metaEnum.Values.Clear();

    var enumList = new MyDependantEnumeratedList();
    using var db = new MyDataConnection();
    foreach (var item in enumList.GetEnumValues(db))
        metaEnum.Values.Add(new Seal.Model.MetaEV { Id = enumList.GetKey(item).ToString(), Val = enumList.GetDisplayText(item) });
}
```

And the followint prompted script:

```
@using LinqToDB.Data
@using Siglas.Queries.EnumeratedLists
@using Siglas.Utils.Data
@{
#nullable enable
    MetaEnum metaEnum = Model;
    metaEnum.NewValues.Clear();

    var parentEnumValues = {EnumValues_MySourceEnumeratedList};
    var parentValues = (parentEnumValues ?? new List<string>())
        .Where(v => !string.IsNullOrEmpty(v))
        .Select(v => int.Parse(v))
        .ToList();

    var enumList = new MyDependantEnumeratedList();
    using var db = new MyDataConnection();

    foreach (var item in enumList.GetEnumValues(db, parentValues))
        metaEnum.NewValues.Add(new Seal.Model.MetaEV { Id = enumList.GetKey(item).ToString(), Val = enumList.GetDisplayText(item) });
}
```

(The code to get enumerated list values is implemented on a .net dll, tested and working, the types MyDependantEnumeratedList and MyDataConnection are implemented in the c# dll with mock values to minimize the possible failing points on the test)

Once I load the report, both lists work exactly as expected, filtering the appropiate results between them and also filtering the report results perfectly.

The problem is, when I execute the report, once the results are shown, and I can modify the filters to make a new query, the drop for the dependant list contains all the values of the table instead of the filtered ones, just as if it was using the display script instead of the prompted restriction script.

### **Steps to reproduce**

Open a report with two dependent enum restrictions: a parent and a child 
Select a value in the parent restriction — the child list filters correctly.
Select a value in the child restriction and execute the report.
After execution completes, open the child dropdown again.

### **Expected**

 The child list shows only the values that correspond to the selected parent value.

### **Actual**

 The child list shows all values, ignoring the parent selection.

### **Fix**

I've been able to fix it by modifying the GetEnumValues method of the ReportExecution class. I don't know if I understood it the right way but as I understand, when recovering the enum values, it should add the values of the restriction on the report execution (the one in Report.AllExecutionRestriction) instead of the prompted one.

### **Testing**

I've run tests and manyally tested many reports of the samples repository with linked enums and I haven't found anything wrong.