### PR TITLE
Harden Razor engine security and remediate dependency CVEs

### DIFF
--- a/Projects/SealDocumentation/Pages/Index.cshtml
+++ b/Projects/SealDocumentation/Pages/Index.cshtml
@@ -365,10 +365,10 @@
                                     <strong>Assemblies:</strong> additional DLL (*.dll) that can be referenced in all Razor scripts. You can add your own assemblies in this folder and call them from any script compiled and executed during a report execution (e.g. in a Task).
                                 </li>
                                 <li>
-                                    <strong>Assemblies\Dynamics:</strong> additional source code files (*.cs) to be compiled and loaded. You can then reference the <b>Classes</b> compiled from any script (e.g. in a Task).
+                                    <strong>Assemblies\Dynamics:</strong> additional source code files (*.cs) to be compiled and loaded. You can then reference the <b>Classes</b> compiled from any script (e.g. in a Task). The compiled assemblies are stored in the <b>Net</b> (non-Windows runtime) and <b>Win</b> (Windows applications) sub-folders.
                                 </li>
                                 <li>
-                                    <strong>Assemblies\RazorCache:</strong> Cache folder to store the assemblies compiled from static template files (Views, Tables and Tasks).
+                                    <strong>Assemblies\RazorCache\Net:</strong> Cache folder to store the assemblies compiled from static template files (Views, Tables and Tasks) for the .NET (non-Windows) runtime.
                                 </li>
                                 <li>
                                     <strong>Assemblies\RazorCache\Win:</strong> Cache folder to store the assemblies compiled from static template files (Views, Tables and Tasks) for SealLibraryWin (Windows applications).

--- a/Projects/SealLibrary/SealLibrary.csproj
+++ b/Projects/SealLibrary/SealLibrary.csproj
@@ -182,8 +182,9 @@
 		<PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="10.0.7" />
 		<PackageReference Include="Microsoft.Data.SqlClient" Version="7.0.1" />
 		<PackageReference Include="Microsoft.Data.SqlClient.AlwaysEncrypted.AzureKeyVaultProvider" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Graph" Version="5.104.0" />
-		<PackageReference Include="MongoDB.Driver" Version="3.8.0" />
+		<!-- Graph 6.x pulls Graph.Core 4.x -> Kiota 2.x, which is already above the GHSA-7j59-v9qr-6fq9 fix (1.22.0); no Kiota pin needed -->
+		<PackageReference Include="Microsoft.Graph" Version="6.2.0" />
+		<PackageReference Include="MongoDB.Driver" Version="3.9.0" />
 		<PackageReference Include="MySql.Data" Version="9.7.0" />
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
 		<PackageReference Include="Npgsql" Version="10.0.2" />

--- a/Projects/SealLibrary/SealLibrary.xml
+++ b/Projects/SealLibrary/SealLibrary.xml
@@ -963,6 +963,25 @@
             Check is the script is valid, may be used to control/limit the scripts executed
             </summary>
         </member>
+        <member name="T:Seal.Helpers.DefaultScriptValidator">
+            <summary>
+            Optional, opt-in deny-list validator (defense-in-depth) wired by Repository.Init when
+            SealServerConfiguration.EnableRazorScriptValidation is true. DISABLED by default because
+            Seal scripts may legitimately use file/process/reflection APIs (e.g. report tasks).
+            IMPORTANT: a substring deny-list on a Turing-complete language can be bypassed — this is
+            only a speed-bump. The real security boundary remains "who is allowed to author/edit
+            Razor scripts (reports, meta sources, security providers, dynamics)".
+            </summary>
+        </member>
+        <member name="F:Seal.Helpers.DefaultScriptValidator.DefaultForbiddenTokens">
+            <summary>Conservative starter deny-list, used when no custom tokens are configured.</summary>
+        </member>
+        <member name="M:Seal.Helpers.DefaultScriptValidator.#ctor(System.Collections.Generic.IEnumerable{System.String})">
+            <param name="forbiddenTokens">Custom forbidden substrings; when null/empty the built-in starter list is used.</param>
+        </member>
+        <member name="M:Seal.Helpers.DefaultScriptValidator.CheckScript(System.String)">
+            <summary>Reject the script if it contains any forbidden token (case-insensitive).</summary>
+        </member>
         <member name="T:Seal.Helpers.RawContent">
             <summary>
             Marker for content that must be emitted RAW (not HTML-encoded), mirroring the fork's IEncodedString/RawString.
@@ -997,6 +1016,12 @@
             Reached only via RazorHelper when UseRazorCore is enabled.
             </summary>
         </member>
+        <member name="F:Seal.Helpers.RazorCoreEngine._engineVersion">
+            <summary>
+            Version stamp folded into every persisted cache file name so a compiled assembly built
+            against an older base template / helper API is never reused after a Seal upgrade.
+            </summary>
+        </member>
         <member name="M:Seal.Helpers.RazorCoreEngine.NoSyncContext``1(System.Func{``0})">
             <summary>
             Run a RazorEngineCore call with no ambient SynchronizationContext. RazorEngineCore's synchronous
@@ -1005,7 +1030,14 @@
             </summary>
         </member>
         <member name="M:Seal.Helpers.RazorCoreEngine.CacheFileName(System.String)">
-            <summary>Stable, filesystem-safe file name for a (possibly path-like) cache key.</summary>
+            <summary>
+            Stable, filesystem-safe file name BOUND TO THE SCRIPT CONTENT (not the logical cache key).
+            Binding the name to the content (plus the engine version) means any change to the script
+            yields a different file, so a stale or mismatched persisted assembly is never silently
+            trusted, and a DLL compiled for one script can never be reused for a different script that
+            happens to share a key. (The repository 'Assemblies' tree — including this RazorCache
+            folder — is loaded as in-process code and must be writable only by the service account.)
+            </summary>
         </member>
         <member name="M:Seal.Helpers.RazorCoreEngine.Compile(System.String,System.String,System.String,System.Nullable{System.DateTime})">
             <summary>
@@ -7707,22 +7739,32 @@
         </member>
         <member name="P:Seal.Model.Repository.DynamicsFolder">
             <summary>
-            Dynamic assemblies folder
+            Dynamic assemblies folder: holds the source .cs files (shared by all runtimes). Compiled assemblies go to the Net/Win sub-folders.
+            </summary>
+        </member>
+        <member name="P:Seal.Model.Repository.DynamicsNetFolder">
+            <summary>
+            Dynamic assemblies folder for the .NET (non-Windows) runtime: holds the compiled assemblies.
             </summary>
         </member>
         <member name="P:Seal.Model.Repository.DynamicsWinFolder">
             <summary>
-            Dynamic assemblies folder for Windows applications
+            Dynamic assemblies folder for Windows applications: holds the compiled assemblies.
             </summary>
         </member>
         <member name="P:Seal.Model.Repository.RazorCacheFolder">
             <summary>
-            Razor cache folder for compiled assemblies
+            Razor cache parent folder. Compiled assemblies are stored in the Net/Win sub-folders.
+            </summary>
+        </member>
+        <member name="P:Seal.Model.Repository.RazorCacheNetFolder">
+            <summary>
+            Razor cache folder for compiled assemblies for the .NET (non-Windows) runtime.
             </summary>
         </member>
         <member name="P:Seal.Model.Repository.RazorCacheWinFolder">
             <summary>
-            Razor cache folder for compiled assemblies for Windows applications
+            Razor cache folder for compiled assemblies for Windows applications.
             </summary>
         </member>
         <member name="P:Seal.Model.Repository.SealConverterPath">
@@ -9271,6 +9313,16 @@
         <member name="P:Seal.Model.SealServerConfiguration.EnableRazorCache">
             <summary>
             If true, standard razor script used for templates (Views, Tables, Tasks and Security Providers) are compiled and stored in the 'Assemblies\\RazorCache' repository folder. This speed-up the application start-up.
+            </summary>
+        </member>
+        <member name="P:Seal.Model.SealServerConfiguration.EnableRazorScriptValidation">
+            <summary>
+            If true, Razor scripts are checked against a deny-list of API tokens before compilation (defense-in-depth). Disabled by default as scripts may legitimately use file/process/reflection APIs. The primary control remains restricting who can edit scripts.
+            </summary>
+        </member>
+        <member name="P:Seal.Model.SealServerConfiguration.RazorForbiddenTokens">
+            <summary>
+            Case-insensitive substrings forbidden in Razor scripts when 'Enable Razor Script Validation' is true, one per line. Lines starting with // are ignored. If empty, a conservative built-in starter list is used.
             </summary>
         </member>
         <member name="P:Seal.Model.SealServerConfiguration.EnableDownloadUpload">

--- a/Projects/SealLibraryWin/Forms/TemplateTextEditor.cs
+++ b/Projects/SealLibraryWin/Forms/TemplateTextEditor.cs
@@ -1013,6 +1013,34 @@ $('<div>', {{
 }
 ";
 
+        //Sample proposed in the editor for the 'Razor Forbidden Tokens' configuration property: the active built-in deny-list plus
+        //commented suggestions the admin can enable by removing the leading //. Lines starting with // are ignored at runtime.
+        static readonly string razorForbiddenTokensSample =
+            "// One forbidden substring per line (case-insensitive). Lines starting with // are ignored.\r\n" +
+            "// A Razor script containing any of these substrings is rejected before compilation.\r\n" +
+            "// Leave this list unchanged to use the built-in defaults below.\r\n" +
+            "\r\n" +
+            "// --- Built-in default deny-list (active) ---\r\n" +
+            string.Join("\r\n", DefaultScriptValidator.DefaultForbiddenTokens) + "\r\n" +
+            "\r\n" +
+            "// --- More suggestions (remove the // to enable) ---\r\n" +
+            "// System.IO.File\r\n" +
+            "// System.IO.Directory\r\n" +
+            "// System.IO.Path\r\n" +
+            "// System.Net.WebClient\r\n" +
+            "// System.Net.Http\r\n" +
+            "// System.Net.Sockets\r\n" +
+            "// System.Reflection\r\n" +
+            "// AppDomain\r\n" +
+            "// Activator.CreateInstance\r\n" +
+            "// System.Runtime.Loader\r\n" +
+            "// Microsoft.CSharp\r\n" +
+            "// CSharpCodeProvider\r\n" +
+            "// System.Management\r\n" +
+            "// Environment.SetEnvironmentVariable\r\n" +
+            "// cmd.exe\r\n" +
+            "// powershell";
+
         static readonly Tuple<string, string>[] tasksSamples =
         {
             new Tuple<string, string>(
@@ -2108,6 +2136,14 @@ $('<div>', {{
                         template = Audit.AuditScriptTemplate;
                         frm.ObjectForCheckSyntax = new Audit();
                         frm.Text = "Edit the script executed when a an audit event occurs";
+                        ScintillaHelper.Init(frm.textBox, Lexer.Cpp);
+                    }
+                    else if (context.PropertyDescriptor.Name == "RazorForbiddenTokens")
+                    {
+                        //Simple multi-line list (one forbidden substring per line) with proposed sample keywords.
+                        //C# lexer so the // comments and the .NET type tokens are syntax-highlighted.
+                        template = razorForbiddenTokensSample;
+                        frm.Text = "Edit the Razor forbidden tokens (one substring per line)";
                         ScintillaHelper.Init(frm.textBox, Lexer.Cpp);
                     }
                 }

--- a/Projects/SealLibraryWin/Helpers/RazorCoreEngine.cs
+++ b/Projects/SealLibraryWin/Helpers/RazorCoreEngine.cs
@@ -64,6 +64,13 @@ namespace Seal.Helpers
         static readonly ConcurrentDictionary<string, IRazorEngineCompiledTemplate<SealCoreTemplateBase>> _cache = new();
         static readonly object _lock = new object();
 
+        /// <summary>
+        /// Version stamp folded into every persisted cache file name so a compiled assembly built
+        /// against an older base template / helper API is never reused after a Seal upgrade.
+        /// </summary>
+        static readonly string _engineVersion =
+            typeof(SealCoreTemplateBase).Assembly.GetName().Version?.ToString() ?? "0";
+
         public static bool IsTemplateCached(string key) => !string.IsNullOrEmpty(key) && _cache.ContainsKey(key);
 
         /// <summary>
@@ -80,11 +87,18 @@ namespace Seal.Helpers
             finally { SynchronizationContext.SetSynchronizationContext(ctx); }
         }
 
-        /// <summary>Stable, filesystem-safe file name for a (possibly path-like) cache key.</summary>
-        static string CacheFileName(string key)
+        /// <summary>
+        /// Stable, filesystem-safe file name BOUND TO THE SCRIPT CONTENT (not the logical cache key).
+        /// Binding the name to the content (plus the engine version) means any change to the script
+        /// yields a different file, so a stale or mismatched persisted assembly is never silently
+        /// trusted, and a DLL compiled for one script can never be reused for a different script that
+        /// happens to share a key. (The repository 'Assemblies' tree — including this RazorCache
+        /// folder — is loaded as in-process code and must be writable only by the service account.)
+        /// </summary>
+        static string CacheFileName(string script)
         {
             using var sha = SHA256.Create();
-            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(key));
+            var hash = sha.ComputeHash(Encoding.UTF8.GetBytes(_engineVersion + "\0" + (script ?? "")));
             return Convert.ToHexString(hash) + ".dll";
         }
 
@@ -100,7 +114,7 @@ namespace Seal.Helpers
             {
                 if (_cache.ContainsKey(key)) return;
 
-                string dll = string.IsNullOrEmpty(cacheDir) ? null : Path.Combine(cacheDir, CacheFileName(key));
+                string dll = string.IsNullOrEmpty(cacheDir) ? null : Path.Combine(cacheDir, CacheFileName(script));
 
                 // 1) reuse a persisted assembly if present and not stale
                 if (dll != null && File.Exists(dll))

--- a/Projects/SealLibraryWin/Helpers/RazorHelper.cs
+++ b/Projects/SealLibraryWin/Helpers/RazorHelper.cs
@@ -3,6 +3,7 @@
 // Licensed under the Seal Report Dual-License version 1.0; you may not use this file except in compliance with the License described at https://github.com/ariacom/Seal-Report.
 //
 using System;
+using System.Collections.Generic;
 using System.Data;
 #if WINDOWS
 using System.Windows.Forms;
@@ -169,10 +170,12 @@ namespace Seal.Helpers
         {
             if (model != null && script != null && script.Trim().StartsWith("@"))
             {
+                //Validate on every call, not only on (re)compilation: a script already in the
+                //in-memory or on-disk cache must not be able to skip validation.
+                if (Validator != null && !Validator.CheckScript(script)) throw InvalidScript();
                 var coreKey = GetCoreKey(script, model, key);
                 if (!RazorCoreEngine.IsTemplateCached(coreKey))
                 {
-                    if (Validator != null && !Validator.CheckScript(script)) throw InvalidScript();
                     RazorCoreEngine.Compile(GetFullScript(script), coreKey, RazorCacheDirectory, lastModification);
                 }
                 var result = RazorCoreEngine.Run(coreKey, model);
@@ -199,10 +202,11 @@ namespace Seal.Helpers
         {
             if (model != null && script != null && script.Trim().StartsWith("@"))
             {
+                //Validate on every call (see CompileExecute): a cached script must not bypass validation.
+                if (Validator != null && !Validator.CheckScript(script)) throw InvalidScript();
                 var coreKey = GetCoreKey(script, model, key);
                 if (!RazorCoreEngine.IsTemplateCached(coreKey))
                 {
-                    if (Validator != null && !Validator.CheckScript(script)) throw InvalidScript();
                     RazorCoreEngine.Compile(script, coreKey, RazorCacheDirectory, lastModification);
                 }
                 return coreKey;
@@ -226,5 +230,49 @@ namespace Seal.Helpers
             return true;
         }
 
+    }
+
+    /// <summary>
+    /// Optional, opt-in deny-list validator (defense-in-depth) wired by Repository.Init when
+    /// SealServerConfiguration.EnableRazorScriptValidation is true. DISABLED by default because
+    /// Seal scripts may legitimately use file/process/reflection APIs (e.g. report tasks).
+    /// IMPORTANT: a substring deny-list on a Turing-complete language can be bypassed — this is
+    /// only a speed-bump. The real security boundary remains "who is allowed to author/edit
+    /// Razor scripts (reports, meta sources, security providers, dynamics)".
+    /// </summary>
+    public class DefaultScriptValidator : ScriptValidator
+    {
+        /// <summary>Conservative starter deny-list, used when no custom tokens are configured.</summary>
+        public static readonly string[] DefaultForbiddenTokens = new[]
+        {
+            "System.Diagnostics.Process", "Process.Start",
+            "System.Reflection.Emit", "Assembly.Load", "Assembly.LoadFrom", "Assembly.LoadFile",
+            "System.Runtime.InteropServices", "DllImport", "Marshal.",
+            "Microsoft.Win32.Registry", "Environment.Exit", "Environment.FailFast",
+        };
+
+        readonly string[] _forbidden;
+
+        /// <param name="forbiddenTokens">Custom forbidden substrings; when null/empty the built-in starter list is used.</param>
+        public DefaultScriptValidator(IEnumerable<string> forbiddenTokens = null)
+        {
+            var tokens = forbiddenTokens?.Where(t => !string.IsNullOrWhiteSpace(t)).ToArray();
+            _forbidden = (tokens != null && tokens.Length > 0) ? tokens : DefaultForbiddenTokens;
+        }
+
+        /// <summary>Reject the script if it contains any forbidden token (case-insensitive).</summary>
+        public override bool CheckScript(string script)
+        {
+            if (string.IsNullOrEmpty(script)) return true;
+            foreach (var token in _forbidden)
+            {
+                if (script.IndexOf(token, StringComparison.OrdinalIgnoreCase) >= 0)
+                {
+                    Helper.WriteLogEntry("Seal Razor", EventLogEntryType.Warning, $"A Razor script was rejected by the script validator (forbidden token '{token}').");
+                    return false;
+                }
+            }
+            return true;
+        }
     }
 }

--- a/Projects/SealLibraryWin/Model/Repository.cs
+++ b/Projects/SealLibraryWin/Model/Repository.cs
@@ -548,7 +548,18 @@ namespace Seal.Model
             //Razor cache directory
             if (Configuration.EnableRazorCache)
             {
-                RazorHelper.RazorCacheDirectory = Configuration.IsUsingSealLibraryWin ? RazorCacheWinFolder : RazorCacheFolder;
+                RazorHelper.RazorCacheDirectory = Configuration.IsUsingSealLibraryWin ? RazorCacheWinFolder : RazorCacheNetFolder;
+            }
+
+            //Optional Razor script validation (defense-in-depth). Off by default; a host app may set its own Validator beforehand, which then wins.
+            if (Configuration.EnableRazorScriptValidation && RazorHelper.Validator == null)
+            {
+                //Forbidden tokens are edited as a multi-line list: one substring per line, // lines are comments
+                var forbiddenTokens = (Configuration.RazorForbiddenTokens ?? "")
+                    .Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)
+                    .Select(i => i.Trim())
+                    .Where(i => i.Length > 0 && !i.StartsWith("//"));
+                RazorHelper.Validator = new DefaultScriptValidator(forbiddenTokens);
             }
 
             //Data sources
@@ -630,9 +641,16 @@ namespace Seal.Model
 
                 if (!DynamicAssembliesLoaded)
                 {
+                    //Force the load of every available assembly BEFORE compiling the Dynamics classes.
+                    //GetAssemblies() below only sees assemblies already loaded into the AppDomain; .NET loads
+                    //lazily, so without this a Dynamics .cs referencing an as-yet-untouched assembly (e.g. Json,
+                    //Mongo, SshNet, ScottPlot...) would fail to compile with "type is defined in an assembly that
+                    //is not referenced". This is the same complete reference set Razor scripts compile against.
+                    RazorHelper.LoadRazorAssemblies();
+
                     //Load extra dynamic assemblies
                     var csFiles = Directory.GetFiles(DynamicsFolder, "*.cs");
-                    var dynamicFolder = Configuration.IsUsingSealLibraryWin ? DynamicsWinFolder : DynamicsFolder;
+                    var dynamicFolder = Configuration.IsUsingSealLibraryWin ? DynamicsWinFolder : DynamicsNetFolder;
                     foreach (var csFile in csFiles.OrderBy(i => i))
                     {
                         try
@@ -710,8 +728,11 @@ namespace Seal.Model
 
         Assembly AssemblyResolve(object sender, ResolveEventArgs args)
         {
-            string assemblyPath = Path.Combine(AssembliesFolder, new AssemblyName(args.Name).Name + ".dll");
-            if (!File.Exists(assemblyPath)) assemblyPath = Path.Combine(DynamicsFolder, new AssemblyName(args.Name).Name + ".dll");
+            var name = new AssemblyName(args.Name).Name + ".dll";
+            string assemblyPath = Path.Combine(AssembliesFolder, name);
+            //Dynamic assemblies live in the runtime sub-folder (Net/Win); fall back to the Dynamics root for back-compat
+            if (!File.Exists(assemblyPath)) assemblyPath = Path.Combine(Configuration.IsUsingSealLibraryWin ? DynamicsWinFolder : DynamicsNetFolder, name);
+            if (!File.Exists(assemblyPath)) assemblyPath = Path.Combine(DynamicsFolder, name);
             if (!File.Exists(assemblyPath)) return null;
             Assembly assembly = Assembly.LoadFrom(assemblyPath);
             return assembly;
@@ -761,9 +782,10 @@ namespace Seal.Model
                 if (!Directory.Exists(SecurityFolder)) Directory.CreateDirectory(SecurityFolder);
                 if (!Directory.Exists(SecurityProvidersFolder)) Directory.CreateDirectory(SecurityProvidersFolder);
                 if (!Directory.Exists(AssembliesFolder)) Directory.CreateDirectory(AssembliesFolder);
-                if (!Directory.Exists(DynamicsWinFolder)) Directory.CreateDirectory(DynamicsWinFolder);
                 if (!Directory.Exists(DynamicsFolder)) Directory.CreateDirectory(DynamicsFolder);
-                if (!Directory.Exists(RazorCacheFolder)) Directory.CreateDirectory(RazorCacheFolder);
+                if (!Directory.Exists(DynamicsNetFolder)) Directory.CreateDirectory(DynamicsNetFolder);
+                if (!Directory.Exists(DynamicsWinFolder)) Directory.CreateDirectory(DynamicsWinFolder);
+                if (!Directory.Exists(RazorCacheNetFolder)) Directory.CreateDirectory(RazorCacheNetFolder);
                 if (!Directory.Exists(RazorCacheWinFolder)) Directory.CreateDirectory(RazorCacheWinFolder);
                 if (!Directory.Exists(SubReportsFolder)) Directory.CreateDirectory(SubReportsFolder);
                 if (!Directory.Exists(SpecialsFolder)) Directory.CreateDirectory(SpecialsFolder);
@@ -941,7 +963,7 @@ namespace Seal.Model
         }
 
         /// <summary>
-        /// Dynamic assemblies folder
+        /// Dynamic assemblies folder: holds the source .cs files (shared by all runtimes). Compiled assemblies go to the Net/Win sub-folders.
         /// </summary>
         public string DynamicsFolder
         {
@@ -952,7 +974,18 @@ namespace Seal.Model
         }
 
         /// <summary>
-        /// Dynamic assemblies folder for Windows applications
+        /// Dynamic assemblies folder for the .NET (non-Windows) runtime: holds the compiled assemblies.
+        /// </summary>
+        public string DynamicsNetFolder
+        {
+            get
+            {
+                return Path.Combine(AssembliesFolder, "Dynamics\\Net");
+            }
+        }
+
+        /// <summary>
+        /// Dynamic assemblies folder for Windows applications: holds the compiled assemblies.
         /// </summary>
         public string DynamicsWinFolder
         {
@@ -963,7 +996,7 @@ namespace Seal.Model
         }
 
         /// <summary>
-        /// Razor cache folder for compiled assemblies
+        /// Razor cache parent folder. Compiled assemblies are stored in the Net/Win sub-folders.
         /// </summary>
         public string RazorCacheFolder
         {
@@ -974,7 +1007,18 @@ namespace Seal.Model
         }
 
         /// <summary>
-        /// Razor cache folder for compiled assemblies for Windows applications
+        /// Razor cache folder for compiled assemblies for the .NET (non-Windows) runtime.
+        /// </summary>
+        public string RazorCacheNetFolder
+        {
+            get
+            {
+                return Path.Combine(AssembliesFolder, "RazorCache\\Net");
+            }
+        }
+
+        /// <summary>
+        /// Razor cache folder for compiled assemblies for Windows applications.
         /// </summary>
         public string RazorCacheWinFolder
         {

--- a/Projects/SealLibraryWin/Model/SealServerConfiguration.cs
+++ b/Projects/SealLibraryWin/Model/SealServerConfiguration.cs
@@ -103,6 +103,8 @@ namespace Seal.Model
                 GetProperty("WebScriptFiles").SetIsBrowsable(!ForPublication); 
                 GetProperty("AlternateTempDirectory").SetIsBrowsable(!ForPublication);
                 GetProperty("EnableRazorCache").SetIsBrowsable(!ForPublication);
+                GetProperty("EnableRazorScriptValidation").SetIsBrowsable(!ForPublication);
+                GetProperty("RazorForbiddenTokens").SetIsBrowsable(!ForPublication);
                 GetProperty("EnableDownloadUpload").SetIsBrowsable(!ForPublication);
                 GetProperty("ReportFormats").SetIsBrowsable(!ForPublication);
 
@@ -211,7 +213,7 @@ namespace Seal.Model
         /// If true, the User Personal Folder (located in the 'SpecialFolders\\Personal' repository sub-folder) containing the profile and personal files is built with the host name. This allows multiple Web sites on the same installation.
         /// </summary>
 #if WINDOWS
-        [Category("Server Settings"), DisplayName("Use host name to define the Personal Folder name"), Description("If true, the User Personal Folder (located in the 'SpecialFolders\\Personal' repository sub-folder) containing the profile and personal files is built with the host name. This allows multiple Web sites on the same installation."), Id(10, 1)]
+        [Category("Server Settings"), DisplayName("Use host name for Personal Folder"), Description("If true, the User Personal Folder (located in the 'SpecialFolders\\Personal' repository sub-folder) containing the profile and personal files is built with the host name. This allows multiple Web sites on the same installation."), Id(10, 1)]
         [DefaultValue(false)]
 #endif
         public bool HostForPersonalFolder { get; set; } = false;
@@ -269,6 +271,26 @@ namespace Seal.Model
 #endif
         public bool EnableRazorCache { get; set; } = true;
         public bool ShouldSerializeEnableRazorCache() { return !EnableRazorCache; }
+
+        /// <summary>
+        /// If true, Razor scripts are checked against a deny-list of API tokens before compilation (defense-in-depth). Disabled by default as scripts may legitimately use file/process/reflection APIs. The primary control remains restricting who can edit scripts.
+        /// </summary>
+#if WINDOWS
+        [Category("Server Settings"), DisplayName("Enable Razor Script Validation"), Description("If true, Razor scripts are checked against a deny-list of API tokens before compilation (defense-in-depth). Disabled by default as scripts may legitimately use file/process/reflection APIs. The tokens can be set with 'Razor Forbidden Tokens'; if none are set, a conservative built-in starter list is used."), Id(24, 1)]
+        [DefaultValue(false)]
+#endif
+        public bool EnableRazorScriptValidation { get; set; } = false;
+        public bool ShouldSerializeEnableRazorScriptValidation() { return EnableRazorScriptValidation; }
+
+        /// <summary>
+        /// Case-insensitive substrings forbidden in Razor scripts when 'Enable Razor Script Validation' is true, one per line. Lines starting with // are ignored. If empty, a conservative built-in starter list is used.
+        /// </summary>
+#if WINDOWS
+        [Category("Server Settings"), DisplayName("Razor Forbidden Tokens"), Description("Case-insensitive substrings forbidden in Razor scripts when 'Enable Razor Script Validation' is true, one per line (lines starting with // are ignored). If empty, a conservative built-in starter list is used (Process.Start, Assembly.Load, Marshal, etc.)."), Id(25, 1)]
+        [Editor(typeof(TemplateTextEditor), typeof(UITypeEditor))]
+#endif
+        public string RazorForbiddenTokens { get; set; } = "";
+        public bool ShouldSerializeRazorForbiddenTokens() { return !string.IsNullOrEmpty(RazorForbiddenTokens); }
 
         /// <summary>
         /// If true, download and upload of files and reports are allowed through the Web Report Server if the user belongs to a group having this right.

--- a/Projects/SealLibraryWin/SealLibraryWin.csproj
+++ b/Projects/SealLibraryWin/SealLibraryWin.csproj
@@ -75,9 +75,10 @@
 		<PackageReference Include="jose-jwt">
 			<Version>5.3.0</Version>
 		</PackageReference>
-		<PackageReference Include="Microsoft.Graph" Version="5.104.0" />
+		<!-- Graph 6.x pulls Graph.Core 4.x -> Kiota 2.x, which is already above the GHSA-7j59-v9qr-6fq9 fix (1.22.0); no Kiota pin needed -->
+		<PackageReference Include="Microsoft.Graph" Version="6.2.0" />
 		<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.3912.50" />
-		<PackageReference Include="MongoDB.Driver" Version="3.8.0" />
+		<PackageReference Include="MongoDB.Driver" Version="3.9.0" />
 		<PackageReference Include="MySql.Data" Version="9.7.0" />
 		<PackageReference Include="Oracle.ManagedDataAccess.Core" Version="23.26.200" />
 		<PackageReference Include="Npgsql" Version="10.0.2" />

--- a/Projects/Tests/TestEmailTemplateCompilation.cs
+++ b/Projects/Tests/TestEmailTemplateCompilation.cs
@@ -1,0 +1,38 @@
+//
+// Copyright (c) Seal Report (sealreport@gmail.com), http://www.sealreport.org.
+// Licensed under the Seal Report Dual-License version 1.0; you may not use this file except in compliance with the License described at https://github.com/ariacom/Seal-Report.
+//
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Seal.Helpers;
+using Seal.Model;
+
+namespace Test
+{
+    /// <summary>
+    /// Compile-only guards for the e-mail device script templates that are compiled at runtime
+    /// (they are never compiled by the build, so an SDK breaking change would otherwise only
+    /// surface in production when an e-mail is actually sent).
+    /// </summary>
+    [TestClass]
+    public class TestEmailTemplateCompilation
+    {
+        /// <summary>
+        /// Compiles the shipped Microsoft Graph e-mail template against the resolved Microsoft.Graph
+        /// SDK. Guards against breaking changes when the Graph NuGet package is bumped (e.g. v5 -> v6):
+        /// a renamed/moved type or namespace in the template surfaces here as a compilation exception.
+        /// Compile-only: the template is not executed, so no Azure credentials or network are needed.
+        /// </summary>
+        [TestMethod]
+        public void CompileMSGraphEmailTemplate()
+        {
+            //Resolves the in-repo repository (Debug) and forces the load of the Razor assemblies.
+            Repository.Create();
+
+            //GetFullScript mirrors what CompileExecute adds in production (the Seal default usings).
+            var script = RazorHelper.GetFullScript(OutputEmailDevice.MSGraphScriptTemplate);
+
+            //Throws TemplateCompilationException if the template no longer compiles against the SDK.
+            RazorHelper.Compile(script, typeof(OutputEmailDevice.EmailDefinition), "TST_MSGraphEmailTemplate");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Two related workstreams on the RazorEngineCore migration branch: **security hardening** of the Razor compilation pipeline, and **remediation of the transitive package CVEs** the build was flagging (including a Microsoft.Graph 5->6 major bump).

## Razor engine security

- **Content-bound cache files.** The persisted Razor cache assembly name is now hashed from the script *content* + engine version, not the logical cache key. Fixes the case where a stale/mismatched compiled assembly was trusted unconditionally when no `lastModification` was supplied, stops a DLL compiled for one script being reused for a different script that shares a key, and auto-invalidates the cache across Seal upgrades.
- **No validation bypass via cache.** `CompileExecute`/`CompilePartial` now validate the script on every call instead of only on (re)compilation, so an already-cached script can no longer skip validation.
- **Opt-in deny-list validator.** New `DefaultScriptValidator` wired through two new configuration settings - `EnableRazorScriptValidation` (default **off**) and `RazorForbiddenTokens` - both editable in the Server Manager. Off by default because Seal scripts may legitimately use file/process/reflection APIs; this is defense-in-depth, not a security boundary (the real boundary remains who may author scripts).

## Dependency CVEs (build now reports no vulnerable packages)

| Package | Change | Advisory |
|---|---|---|
| MongoDB.Driver | 3.8.0 -> 3.9.0 (pulls Snappier >= 1.3.1) | GHSA-pggp-6c3x-2xmx (high) |
| MongoDB.Driver | 3.8.0 -> 3.9.0 (pulls SharpCompress >= 0.48.1) | GHSA-6c8g-7p36-r338 (moderate) |
| Microsoft.Graph | 5.104.0 -> 6.2.0 (pulls Graph.Core 4.x / Kiota 2.x) | GHSA-7j59-v9qr-6fq9 (high) |

The Graph 5->6 bump is a small change (the major Kiota API rewrite was v4->v5); the send-mail API surface is unchanged.

## Verification

- **New test** `Projects/Tests/TestEmailTemplateCompilation.cs` compiles the shipped MS Graph e-mail template against the resolved Graph SDK (compile-only - no Azure creds/network) as a regression guard for future SDK bumps. Passes against Graph 6.2.0.
- `dotnet list package --vulnerable` -> no vulnerable packages.
- TST020 + TST030 pass (exit 0).
- Runner, Report Designer, Web Server and Scheduler Worker build clean.

## Reviewer notes

- The MS Graph send path in `OutputEMailDevice.cs` is a runtime-compiled Razor template (+ a commented sandbox method); the only live SDK references are two `using`s, so the bump can't be validated by the build alone - hence the new compile test.
- AngleSharp `NU1608` remains: a cosmetic version-constraint warning (HtmlSanitizer's nuspec pins an old AngleSharp while Seal directly references the working 1.4.0), not a CVE - intentionally left as-is.

[Generated with Claude Code]